### PR TITLE
Fix injecting string parameters in prepared statements

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -101,7 +101,11 @@ func statement(tmpl string, args []driver.NamedValue) string {
 		} else {
 			re = regexp.MustCompile(fmt.Sprintf("@p%d%s", arg.Ordinal, `\b`))
 		}
-		val := fmt.Sprintf("%v", arg.Value)
+		formatStr := "%v"
+		if _, ok := arg.Value.(string); ok {
+			formatStr = "'%v'"
+		}
+		val := fmt.Sprintf(formatStr, arg.Value)
 		stmt = re.ReplaceAllString(stmt, val)
 	}
 	return stmt


### PR DESCRIPTION
The Impala driver simulates prepared statements and injects parameters client side.
There is a small bug when the parameters are strings.

Testing Done: prepare and run an INSERT statement with varchar parameter